### PR TITLE
Modified test related to issue #1

### DIFF
--- a/src/HtmlFormatter.php
+++ b/src/HtmlFormatter.php
@@ -19,7 +19,10 @@ class HtmlFormatter
 	 */
 	public static function format($html, $indentWith = '    ', $tagsWithoutIndentation = 'html,link,img,meta')
 	{
-		// remove all line feeds and replace tabs with spaces
+		// replace newlines (CRLF and LF), followed by a non-whitespace character, with a space
+		$html = preg_replace('/\\r?\\n([^\s])/', ' $1', $html);
+
+		// remove all remaining line feeds and replace tabs with spaces
 		$html = str_replace(["\n", "\r", "\t"], ['', '', ' '], $html);
 		$elements = preg_split('/(<.+>)/U', $html, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		$dom = self::parseDom($elements);

--- a/tests/unit/HtmlFormatterTest.php
+++ b/tests/unit/HtmlFormatterTest.php
@@ -25,11 +25,16 @@ EOT;
         $this->assertEquals($expected, $this->formatter->format('<p>Test</p>'));
     }
 
-    public function testEssentialLineFeedsWithinBlockTagsAreBeingPreserved()
+    /**
+     * If a text node contains a newline whitespace and *no other whitespace*
+     * between two words, then the newline must be replaced by a space
+     * (otherwise the visual html output would be modified)
+     */
+    public function testEssentialLineFeedsAreBeingPreserved()
     {
         $input = <<<EOT
 <p>Test
-    and some more
+and some more
     Linefeeds</p>
 EOT;
         $expected = <<<EOT
@@ -40,23 +45,4 @@ EOT;
         $this->assertSame($expected, $this->formatter->format($input));
     }
 
-    public function testEssentialLineFeedsWithInlineTagsAreBeingPreserved()
-    {
-        $input = <<<EOT
-<p>
-<span>Test
-and text in a second line</span>
-</p>
-EOT;
-
-        $expected = <<<EOT
-<p>
-    <span>
-        Test and text in a second line
-    </span>
-</p>
-EOT;
-        $this->assertSame($expected, $this->formatter->format($input));
-
-    }
 }

--- a/tests/unit/HtmlFormatterTest.php
+++ b/tests/unit/HtmlFormatterTest.php
@@ -45,4 +45,11 @@ EOT;
         $this->assertSame($expected, $this->formatter->format($input));
     }
 
+    public function testCRLFareReplacedCorrectly()
+    {
+        $input = "<p>one\r\ntwo</p>";
+        $expected = "<p>\n    one two\n</p>";
+        $this->assertSame($expected, $this->formatter->format($input));
+    }
+
 }

--- a/tests/unit/HtmlFormatterTest.php
+++ b/tests/unit/HtmlFormatterTest.php
@@ -25,21 +25,38 @@ EOT;
         $this->assertEquals($expected, $this->formatter->format('<p>Test</p>'));
     }
 
-    public function testLineFeedsWithinTextNodesAreBeingPreserved()
+    public function testEssentialLineFeedsWithinBlockTagsAreBeingPreserved()
     {
-        $actual = <<<EOT
+        $input = <<<EOT
 <p>Test
     and some more
     Linefeeds</p>
 EOT;
         $expected = <<<EOT
 <p>
-    Test
-    and some more
-    Linefeeds
+    Test and some more Linefeeds
+</p>
+EOT;
+        $this->assertSame($expected, $this->formatter->format($input));
+    }
+
+    public function testEssentialLineFeedsWithInlineTagsAreBeingPreserved()
+    {
+        $input = <<<EOT
+<p>
+<span>Test
+and text in a second line</span>
 </p>
 EOT;
 
-        $this->assertEquals($expected, $this->formatter->format($actual));
+        $expected = <<<EOT
+<p>
+    <span>
+        Test and text in a second line
+    </span>
+</p>
+EOT;
+        $this->assertSame($expected, $this->formatter->format($input));
+
     }
 }


### PR DESCRIPTION
I modified the test related to issue #1.
In my opinion, removing additional whitespace produces cleaner output, so I think this is ok. The problem in the current implementation is, that a newline gets removed, even if there's no other whitespace between two word. As a result, the visual presentation in the browser shows two words without whitespace in between.
